### PR TITLE
Add Charts to Dashboard

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -4,6 +4,10 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Models\Material;
+use App\Models\Loan;
+use App\Models\Student;
+use App\Models\Inventory;
 use Illuminate\Support\Facades\Auth;
 
 class HomeController extends Controller
@@ -26,7 +30,66 @@ class HomeController extends Controller
     public function index()
     {
         $user = Auth::user();
+        $departmentId = $user->department_id;
 
-        return view('home', compact('user'));
+        $totalStock = Material::where('department_id', $departmentId)->sum('amount');
+
+        $totalLoaned = Loan::where('department_id', $departmentId)
+        ->with('materials')
+        ->get()
+        ->reduce(function ($carry, $loan) {
+            return $carry + $loan->materials->sum('pivot.quantity');
+        }, 0);
+
+        $totalStudents = Student::where('department_id', $departmentId)->count();
+
+        $totalInventories = Inventory::where('department_id', $departmentId)->count();
+
+        $materialsByCategory = Material::selectRaw('category_id, SUM(amount) as total')
+        ->where('department_id', $departmentId)
+        ->groupBy('category_id')
+        ->with('category')
+        ->get();
+
+        $loanedMaterialsByMonth = [];
+        for ($month = 1; $month <= 12; $month++) {
+            $loanedMaterialsByMonth[$month] = Loan::where('department_id', $departmentId)
+                ->whereMonth('created_at', str_pad($month, 2, '0', STR_PAD_LEFT))
+                ->with('materials')
+                ->get()
+                ->reduce(function ($carry, $loan) {
+                    return $carry + $loan->materials->sum('pivot.quantity');
+                }, 0);
+        }
+
+        $materialsByMonth = [];
+        for ($month = 1; $month <= 12; $month++) {
+            $materialsByMonth[$month] = Inventory::where('department_id', $departmentId)
+                ->whereMonth('created_at', $month)
+                ->with('materials')
+                ->get()
+                ->reduce(function ($carry, $inventory) {
+                    return $carry + $inventory->materials->sum('pivot.quantity');
+                }, 0);
+        }
+
+        $activeStudents = Loan::where('department_id', $departmentId)
+            ->distinct('student_id')
+            ->count('student_id');
+
+        $participationRate = $totalStudents > 0 ? ($activeStudents / $totalStudents) * 100 : 0;
+
+        return view('home', compact(
+            'user',
+            'totalStock',
+            'totalLoaned',
+            'totalStudents',
+            'totalInventories',
+            'materialsByCategory',
+            'loanedMaterialsByMonth',
+            'materialsByMonth',
+            'participationRate',
+            'activeStudents'
+            ));
     }
 }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -442,7 +442,7 @@ return [
             ],
         ],
         'Chartjs' => [
-            'active' => false,
+            'active' => true,
             'files' => [
                 [
                     'type' => 'js',

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -13,8 +13,7 @@
                 <div class="row align-items-center">
                     <div class="col-md-2 text-center">
                         @if ($user->getFirstMediaUrl('userGallery'))
-                            <img src="{{ $user->getFirstMediaUrl('userGallery') }}"
-                                alt="Foto de {{ $user->name }}">
+                            <img src="{{ $user->getFirstMediaUrl('userGallery') }}" alt="Foto de {{ $user->name }}">
                         @else
                             <img src="{{ asset('img/userDefault.png') }}">
                         @endif
@@ -25,30 +24,18 @@
                     </div>
                 </div>
             </div>
-        </div>                
-        <div class="col-lg-12 col-md-12">
-            <div class="card bg-info">
-                <div class="card-body">
-                    <h5 class="card-title">¡Bienvenido a Inventio! 🌟</h5>
-                    <p class="card-text">
-                        Tu plataforma de gestión y control de inventario. Simplifica el manejo de materiales y recursos en
-                        un solo lugar, de forma eficiente y organizada. ¡Explora todas las funciones que hemos diseñado para
-                        facilitar tus tareas diarias!
-                    </p>
-                </div>
-            </div>
         </div>
 
         <div class="col-lg-3 col-6">
             <div class="small-box bg-success">
                 <div class="inner">
-                    <h3>150</h3>
+                    <h3>{{ $totalStock }}</h3>
                     <p>Artículos en Stock</p>
                 </div>
                 <div class="icon">
                     <i class="fas fa-box"></i>
                 </div>
-                <a href="#" class="small-box-footer">
+                <a href="{{ route('materials.index') }}" class="small-box-footer">
                     Más información <i class="fas fa-arrow-circle-right"></i>
                 </a>
             </div>
@@ -57,13 +44,13 @@
         <div class="col-lg-3 col-6">
             <div class="small-box bg-warning">
                 <div class="inner">
-                    <h3>53</h3>
+                    <h3>{{ $totalLoaned }}</h3>
                     <p>Artículos Prestados</p>
                 </div>
                 <div class="icon">
                     <i class="fas fa-hand-holding"></i>
                 </div>
-                <a href="#" class="small-box-footer">
+                <a href="{{ route('loans.index') }}" class="small-box-footer">
                     Más información <i class="fas fa-arrow-circle-right"></i>
                 </a>
             </div>
@@ -72,13 +59,13 @@
         <div class="col-lg-3 col-6">
             <div class="small-box bg-danger">
                 <div class="inner">
-                    <h3>20</h3>
-                    <p>Artículos en Mantenimiento</p>
+                    <h3>{{ $totalInventories }}</h3>
+                    <p>Inventarios Creados</p>
                 </div>
                 <div class="icon">
-                    <i class="fas fa-tools"></i>
+                    <i class="fas fa-box"></i>
                 </div>
-                <a href="#" class="small-box-footer">
+                <a href="{{ route('inventories.index') }}" class="small-box-footer">
                     Más información <i class="fas fa-arrow-circle-right"></i>
                 </a>
             </div>
@@ -87,27 +74,68 @@
         <div class="col-lg-3 col-6">
             <div class="small-box bg-primary">
                 <div class="inner">
-                    <h3>10</h3>
-                    <p>Nuevas Solicitudes</p>
+                    <h3>{{ $totalStudents }}</h3>
+                    <p>Estudiantes Registrados</p>
                 </div>
                 <div class="icon">
-                    <i class="fas fa-bell"></i>
+                    <i class="fas fa-users"></i>
                 </div>
-                <a href="#" class="small-box-footer">
+                <a href="{{ route('students.index') }}" class="small-box-footer">
                     Más información <i class="fas fa-arrow-circle-right"></i>
                 </a>
             </div>
         </div>
 
-        <div class="col-lg-12">
+        <div class="col-lg-6">
             <div class="card">
                 <div class="card-header">
-                    <h3 class="card-title">Gráfico de Inventario</h3>
+                    <h3 class="card-title">Gráfico de Inventario por Categoría</h3>
                 </div>
                 <div class="card-body">
                     <div class="chart">
+                        <canvas id="inventoryCategoryChart"
+                            style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
 
-                        <canvas id="inventoryChart"
+        <div class="col-lg-6">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Materiales Prestados Durante el Año</h3>
+                </div>
+                <div class="card-body">
+                    <div class="chart">
+                        <canvas id="loanedMaterialsChart"
+                            style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-6">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Materiales Ingresados Durante el Año</h3>
+                </div>
+                <div class="card-body">
+                    <div class="chart">
+                        <canvas id="inventoriesChart"
+                            style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-6">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Participación de Estudiantes en los Préstamos</h3>
+                </div>
+                <div class="card-body">
+                    <div class="chart">
+                        <canvas id="studentParticipationChart"
                             style="min-height: 250px; height: 250px; max-height: 250px; max-width: 100%;"></canvas>
                     </div>
                 </div>
@@ -122,15 +150,62 @@
 
 @section('js')
     <script>
-        var ctx = document.getElementById('inventoryChart').getContext('2d');
-        var inventoryChart = new Chart(ctx, {
-            type: 'bar',
+        var ctx = document.getElementById('inventoryCategoryChart').getContext('2d');
+        var inventoryCategoryChart = new Chart(ctx, {
+            type: 'doughnut',
             data: {
-                labels: ['Artículos en Stock', 'Artículos Prestados', 'En Mantenimiento', 'Nuevas Solicitudes'],
+                labels: [
+                    @foreach ($materialsByCategory as $category)
+                        '{{ $category->category->name }}',
+                    @endforeach
+                ],
                 datasets: [{
-                    label: 'Cantidad',
-                    data: [150, 53, 20, 10],
-                    backgroundColor: ['#28a745', '#ffc107', '#dc3545', '#007bff'],
+                    label: 'Cantidad de Materiales',
+                    data: [
+                        @foreach ($materialsByCategory as $category)
+                            {{ $category->total }},
+                        @endforeach
+                    ],
+                    backgroundColor: ['#28a745', '#ffc107', '#dc3545', '#007bff', '#17a2b8', '#ff9f40'],
+                }]
+            },
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: {
+                        display: true,
+                        position: 'top',
+                    }
+                }
+            }
+        });
+        var ctx = document.getElementById('loanedMaterialsChart').getContext('2d');
+        var loanedMaterialsChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre',
+                    'Octubre', 'Noviembre', 'Diciembre'
+                ],
+                datasets: [{
+                    label: 'Materiales Prestados',
+                    data: [
+                        {{ $loanedMaterialsByMonth[1] }},
+                        {{ $loanedMaterialsByMonth[2] }},
+                        {{ $loanedMaterialsByMonth[3] }},
+                        {{ $loanedMaterialsByMonth[4] }},
+                        {{ $loanedMaterialsByMonth[5] }},
+                        {{ $loanedMaterialsByMonth[6] }},
+                        {{ $loanedMaterialsByMonth[7] }},
+                        {{ $loanedMaterialsByMonth[8] }},
+                        {{ $loanedMaterialsByMonth[9] }},
+                        {{ $loanedMaterialsByMonth[10] }},
+                        {{ $loanedMaterialsByMonth[11] }},
+                        {{ $loanedMaterialsByMonth[12] }}
+                    ],
+                    borderColor: '#007bff',
+                    backgroundColor: 'rgba(0, 123, 255, 0.1)',
+                    fill: true,
+                    tension: 0.3
                 }]
             },
             options: {
@@ -139,8 +214,59 @@
                     y: {
                         beginAtZero: true
                     }
+                },
+                plugins: {
+                    tooltip: {
+                        mode: 'index',
+                        intersect: false,
+                    }
                 }
             }
+        });
+        document.addEventListener('DOMContentLoaded', function() {
+            var ctx = document.getElementById('inventoriesChart').getContext('2d');
+            var inventoriesChart = new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto',
+                        'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
+                    ],
+                    datasets: [{
+                        label: 'Cantidad de materiales',
+                        data: @json(array_values($materialsByMonth)),
+                        backgroundColor: 'rgba(54, 162, 235, 0.6)',
+                        borderColor: 'rgba(54, 162, 235, 1)',
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: {
+                            beginAtZero: true
+                        }
+                    }
+                }
+            });
+        });
+        document.addEventListener("DOMContentLoaded", function() {
+            var ctx = document.getElementById('studentParticipationChart').getContext('2d');
+            var participationRate = {{ $participationRate }};
+            var totalStudents = {{ $totalStudents }};
+            var activeStudents = {{ $activeStudents }};
+            var chart = new Chart(ctx, {
+                type: 'pie',
+                data: {
+                    labels: ['Estudiantes Activos en Préstamos', 'Estudiantes Sin Participación'],
+                    datasets: [{
+                        data: [activeStudents, totalStudents - activeStudents],
+                        backgroundColor: ['#4CAF50', '#FF6384']
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false
+                }
+            });
         });
     </script>
 @stop

--- a/resources/views/inventories/create.blade.php
+++ b/resources/views/inventories/create.blade.php
@@ -85,54 +85,51 @@
     </div>
 </div>
 
-@section('js')
-    <script>
-        document.getElementById('addMaterialBtn').addEventListener('click', function() {
-            const materialId = document.getElementById('material_id').value;
-            if (materialId !== "") {
-                const materialName = document.getElementById('material_id').selectedOptions[0].text;
-                const materialDescription = document.getElementById('material_id').selectedOptions[0].getAttribute(
-                    'data-description');
-                const tableBody = document.querySelector('#materialTable tbody');
-                let existingRow = null;
+<script>
+    document.getElementById('addMaterialBtn').addEventListener('click', function() {
+        const materialId = document.getElementById('material_id').value;
+        if (materialId !== "") {
+            const materialName = document.getElementById('material_id').selectedOptions[0].text;
+            const materialDescription = document.getElementById('material_id').selectedOptions[0].getAttribute('data-description');
+            const tableBody = document.querySelector('#materialTable tbody');
+            let existingRow = null;
 
-                tableBody.querySelectorAll('tr').forEach(row => {
-                    const existingMaterialId = row.querySelector('input[name="materials[]"]').value;
-                    if (existingMaterialId === materialId) {
-                        existingRow = row;
-                    }
-                });
-
-                if (existingRow) {
-                    const quantityInput = existingRow.querySelector('input[name="quantities[]"]');
-                    quantityInput.value = parseInt(quantityInput.value) + 1;
-                } else {
-                    const newRow = document.createElement('tr');
-                    newRow.innerHTML = `
-                        <td>${materialName}<input type="hidden" name="materials[]" value="${materialId}"></td>
-                        <td>${materialDescription}</td>
-                        <td><input type="number" class="form-control" name="quantities[]" min="1" value="1"></td>
-                        <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
-                    `;
-                    tableBody.appendChild(newRow);
-
-                    newRow.querySelector('.delete-row').addEventListener('click', function() {
-                        newRow.remove();
-                    });
+            tableBody.querySelectorAll('tr').forEach(row => {
+                const existingMaterialId = row.querySelector('input[name="materials[]"]').value;
+                if (existingMaterialId === materialId) {
+                    existingRow = row;
                 }
+            });
 
-                document.getElementById('material_id').value = '';
+            if (existingRow) {
+                const quantityInput = existingRow.querySelector('input[name="quantities[]"]');
+                quantityInput.value = parseInt(quantityInput.value) + 1;
             } else {
-                Swal.fire({
-                    title: 'Error',
-                    text: 'Por favor seleccione un material.',
-                    icon: 'error',
-                    confirmButtonText: 'Aceptar'
+                const newRow = document.createElement('tr');
+                newRow.innerHTML = `
+                    <td>${materialName}<input type="hidden" name="materials[]" value="${materialId}"></td>
+                    <td>${materialDescription}</td>
+                    <td><input type="number" class="form-control" name="quantities[]" min="1" value="1"></td>
+                    <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
+                `;
+                tableBody.appendChild(newRow);
+
+                newRow.querySelector('.delete-row').addEventListener('click', function() {
+                    newRow.remove();
                 });
             }
-        });
-    </script>
-@endsection
+
+            $('#material_id').val(null).trigger('change');
+        } else {
+            Swal.fire({
+                title: 'Error',
+                text: 'Por favor seleccione un material.',
+                icon: 'error',
+                confirmButtonText: 'Aceptar'
+            });
+        }
+    });
+</script>
 
 <style>
     #materialTable tbody tr:nth-child(odd) {

--- a/resources/views/inventories/edit.blade.php
+++ b/resources/views/inventories/edit.blade.php
@@ -70,7 +70,7 @@
                                                         <td>{{ $material->name }}<input type="hidden" name="materials[]" value="{{ $material->id }}"></td>
                                                         <td>{{ $material->description }}</td>
                                                         <td><input type="number" class="form-control" name="quantities[]" min="1" value="{{ $material->pivot->quantity }}"></td>
-                                                        <td><button type="button" class="btn btn-danger btn-sm delete-row">Eliminar</button></td>
+                                                        <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
                                                     </tr>
                                                 @endforeach
                                             </tbody>
@@ -90,75 +90,58 @@
     </div>
 </div>
 
-@section('js')
-    <script>
-        $(document).ready(function() {
-            $('.select2').select2();
+<script>
+    document.querySelector('#materialTable_{{ $inventory->id }}').addEventListener('click', function(e) {
+            if (e.target.classList.contains('delete-row')) {
+                e.target.closest('tr').remove();
+            }
+    });
 
-            $('#createInventory').on('shown.bs.modal', function () {
-                $('.select2').select2({
-                    tags: true
-                });
-            });
-            $('#edit{{ $inventory->id }}').on('shown.bs.modal', function () {
-                $('.select2').select2({
-                    tags: true
-                });
-            });
+    document.getElementById('addMaterialBtn_{{ $inventory->id }}').addEventListener('click', function() {
+        const materialId = document.getElementById('material_id_{{ $inventory->id }}').value;
 
-            document.querySelector('#materialTable_{{ $inventory->id }}').addEventListener('click', function(e) {
-                    if (e.target.classList.contains('delete-row')) {
-                        e.target.closest('tr').remove();
-                    }
-            });
+        if (materialId !== "") {
+            const materialName = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].text;
+            const materialDescription = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].getAttribute('data-description');
+            const tableBody = document.querySelector('#materialTable_{{ $inventory->id }} tbody');
+            let existingRow = null;
 
-            document.getElementById('addMaterialBtn_{{ $inventory->id }}').addEventListener('click', function() {
-                const materialId = document.getElementById('material_id_{{ $inventory->id }}').value;
-
-                if (materialId !== "") {
-                    const materialName = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].text;
-                    const materialDescription = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].getAttribute('data-description');
-                    const tableBody = document.querySelector('#materialTable_{{ $inventory->id }} tbody');
-                    let existingRow = null;
-
-                    tableBody.querySelectorAll('tr').forEach(row => {
-                        const existingMaterialId = row.querySelector('input[name="materials[]"]').value;
-                        if (existingMaterialId === materialId) {
-                            existingRow = row;
-                        }
-                    });
-
-                    if (existingRow) {
-                        const quantityInput = existingRow.querySelector('input[name="quantities[]"]');
-                        quantityInput.value = parseInt(quantityInput.value) + 1;
-                    } else {
-                        const newRow = document.createElement('tr');
-                        newRow.innerHTML = `
-                            <td>${materialName}<input type="hidden" name="materials[]" value="${materialId}"></td>
-                            <td>${materialDescription}</td>
-                            <td><input type="number" class="form-control" name="quantities[]" min="1" value="1"></td>
-                            <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
-                        `;
-                        tableBody.appendChild(newRow);
-
-                        newRow.querySelector('.delete-row').addEventListener('click', function() {
-                            newRow.remove();
-                        });
-                    }
-
-                    document.getElementById('material_id_{{ $inventory->id }}').value = '';
-                } else {
-                    Swal.fire({
-                        title: 'Error',
-                        text: 'Por favor seleccione un material.',
-                        icon: 'error',
-                        confirmButtonText: 'Aceptar'
-                    });
+            tableBody.querySelectorAll('tr').forEach(row => {
+                const existingMaterialId = row.querySelector('input[name="materials[]"]').value;
+                if (existingMaterialId === materialId) {
+                    existingRow = row;
                 }
             });
-        });
-    </script>
-@endsection
+
+            if (existingRow) {
+                const quantityInput = existingRow.querySelector('input[name="quantities[]"]');
+                quantityInput.value = parseInt(quantityInput.value) + 1;
+            } else {
+                const newRow = document.createElement('tr');
+                newRow.innerHTML = `
+                    <td>${materialName}<input type="hidden" name="materials[]" value="${materialId}"></td>
+                    <td>${materialDescription}</td>
+                    <td><input type="number" class="form-control" name="quantities[]" min="1" value="1"></td>
+                    <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
+                `;
+                tableBody.appendChild(newRow);
+
+                newRow.querySelector('.delete-row').addEventListener('click', function() {
+                    newRow.remove();
+                });
+            }
+
+            $('#material_id_{{ $inventory->id }}').val(null).trigger('change');
+        } else {
+            Swal.fire({
+                title: 'Error',
+                text: 'Por favor seleccione un material.',
+                icon: 'error',
+                confirmButtonText: 'Aceptar'
+            });
+        }
+    });
+</script>
 
 <style>
     #materialTable_{{ $inventory->id }} tbody tr:nth-child(odd) {

--- a/resources/views/inventories/index.blade.php
+++ b/resources/views/inventories/index.blade.php
@@ -94,46 +94,61 @@
 @endsection
 
 @section('js')
-<script>
-    $(document).ready(function() {
-        $('#inventories','#tableShow').DataTable({
-            responsive: true,
-            paging: false,
-            info: false,
-            searching: false
+    <script>
+        $(document).ready(function() {
+            $('.select2').select2();
+
+            $('#createInventory').on('shown.bs.modal', function () {
+                $('.select2').select2({
+                    tags: true
+                });
+            });
+            $('#edit{{ $inventory->id }}').on('shown.bs.modal', function () {
+                $('.select2').select2({
+                    tags: true
+                });
+            });
+
+            $(document).ready(function() {
+                $('#inventories','#tableShow').DataTable({
+                    responsive: true,
+                    paging: false,
+                    info: false,
+                    searching: false
+                });
+                var successMessage = "{{ session('success') }}";
+                var errorMessage = "{{ session('error') }}";
+                if (successMessage) {
+                    Swal.fire({
+                        title: 'Éxito',
+                        text: successMessage,
+                        icon: 'success',
+                        confirmButtonText: 'Aceptar'
+                    }).then((result) => {
+                        window.location.href = "{{ route('inventories.index') }}";
+                    });
+                }
+                if (errorMessage) {
+                    Swal.fire({
+                        title: 'Error',
+                        text: errorMessage,
+                        icon: 'error',
+                        confirmButtonText: 'Aceptar'
+                    }).then((result) => {
+                        window.location.href = "{{ route('inventories.index') }}";
+                    });
+                }
+            });
         });
-        var successMessage = "{{ session('success') }}";
-        var errorMessage = "{{ session('error') }}";
-        if (successMessage) {
-            Swal.fire({
-                title: 'Éxito',
-                text: successMessage,
-                icon: 'success',
-                confirmButtonText: 'Aceptar'
-            }).then((result) => {
-                window.location.href = "{{ route('inventories.index') }}";
-            });
-        }
-        if (errorMessage) {
-            Swal.fire({
-                title: 'Error',
-                text: errorMessage,
-                icon: 'error',
-                confirmButtonText: 'Aceptar'
-            }).then((result) => {
-                window.location.href = "{{ route('inventories.index') }}";
-            });
-        }
-    });
-</script>
+    </script>
 @endsection
 
 @section('css')
-<style>
-    .select2-container .select2-selection--single {
-        height: 40px;
-        display: flex;
-        align-items: center;
-    }
-</style>
+    <style>
+        .select2-container .select2-selection--single {
+            height: 40px;
+            display: flex;
+            align-items: center;
+        }
+    </style>
 @endsection


### PR DESCRIPTION
This PR introduces charts to the dashboard, resolves SweetAlert display issues, and enhances the inventory edit view. The changes include:

HomeController.php: Added logic to retrieve data for dashboard charts.
adminlte.php: Updated configuration to integrate charts into the dashboard layout.
home.blade.php: Added sections to display charts in the dashboard view.
inventories/create.blade.php: Fixed SweetAlert display issues and adjusted layout to match
inventories/edit.blade.php:
Updated the delete button in the materials table with an icon for better UX.
Simplified event listeners for row deletion and material addition.
Improved logic for handling duplicate materials by increasing the quantity of an existing material or adding a new row when a material is selected.
Reset the material selection after adding a new material.
Fixed SweetAlert to display an error message if no material is selected.
inventories/index.blade.php:Fixed SweetAlert to correctly display success and error messages.
