### PR TITLE
fix: Update Select2 styles, adjust inventory quantity handling

### DIFF
--- a/app/Models/Inventory.php
+++ b/app/Models/Inventory.php
@@ -17,6 +17,7 @@ class Inventory extends Model implements HasMedia
         'department_id',
         'created_by',
         'status',
+        'detail',
     ];
 
     public function materials()

--- a/database/migrations/2024_09_17_214828_create_inventories_table.php
+++ b/database/migrations/2024_09_17_214828_create_inventories_table.php
@@ -18,6 +18,7 @@ class CreateInventoriesTable extends Migration
             $table->unsignedBigInteger('department_id');
             $table->unsignedBigInteger('created_by');
             $table->string('status');
+            $table->text('detail');
             $table->timestamps();
 
             $table->foreign('department_id')->references('id')->on('departments')->onDelete('cascade');

--- a/database/seeders/InventoriesTableSeeder.php
+++ b/database/seeders/InventoriesTableSeeder.php
@@ -25,6 +25,7 @@ class InventoriesTableSeeder extends Seeder
                 'department_id' => 1,
                 'created_by'    => $faker->randomElement($userIds),
                 'status'        => $faker->randomElement(['disponible', 'no disponible']),
+                'detail'        => $faker->sentence,
                 'created_at'    => now(),
                 'updated_at'    => now(),
             ]);

--- a/database/seeders/InventoryMaterialsTableSeeder.php
+++ b/database/seeders/InventoryMaterialsTableSeeder.php
@@ -33,14 +33,16 @@ class InventoryMaterialsTableSeeder extends Seeder
                 foreach ($selectedMaterials as $materialId) {
                     if ($currentRecords >= $totalRecords) break;
 
+                    $quantity = $faker->numberBetween(10, 30);
                     DB::table('inventory_material')->insert([
                         'inventory_id' => $inventoryId,
                         'material_id'  => $materialId,
-                        'quantity'     => $faker->numberBetween(10, 30),
+                        'quantity'     => $quantity,
                         'created_at'   => now(),
                         'updated_at'   => now(),
                     ]);
 
+                    DB::table('materials')->where('id', $materialId)->increment('amount', $quantity);
                     $currentRecords++;
                 }
             }

--- a/resources/views/inventories/create.blade.php
+++ b/resources/views/inventories/create.blade.php
@@ -72,6 +72,12 @@
                                         </table>
                                     </div>
                                 </div>
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label for="detail" class="form-label">Detalles:</label>
+                                        <textarea name="detail" class="form-control" placeholder="Detalles de Préstamo" required></textarea>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/inventories/edit.blade.php
+++ b/resources/views/inventories/edit.blade.php
@@ -27,18 +27,7 @@
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-lg-6">
-                                        <div class="form-group">
-                                            <label for="material_id" class="form-label">Material(*)</label>
-                                            <select class="form-control select2" id="material_id_{{ $inventory->id }}">
-                                                <option value="">Seleccione un material</option>
-                                                @foreach($materials as $material)
-                                                    <option value="{{ $material->id }}" data-description="{{ $material->description }}">{{ $material->name }}</option>
-                                                @endforeach
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="col-lg-6">
+                                    <div class="col-lg-12">
                                         <div class="form-group">
                                             <label for="status" class="form-label">Estado(*)</label>
                                             <select class="form-control select2" id="status" name="status" required>
@@ -46,11 +35,6 @@
                                                 <option value="no disponible" {{ $inventory->status == 'no disponible' ? 'selected' : '' }}>No disponible</option>
                                             </select>
                                         </div>
-                                    </div>
-                                </div>
-                                <div class="col-lg-12">
-                                    <div class="form-group">
-                                        <button type="button" id="addMaterialBtn_{{ $inventory->id }}" class="btn btn-primary">Agregar Material</button>
                                     </div>
                                 </div>
                                 <div class="row">
@@ -69,12 +53,18 @@
                                                     <tr>
                                                         <td>{{ $material->name }}<input type="hidden" name="materials[]" value="{{ $material->id }}"></td>
                                                         <td>{{ $material->description }}</td>
-                                                        <td><input type="number" class="form-control" name="quantities[]" min="1" value="{{ $material->pivot->quantity }}"></td>
-                                                        <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
+                                                        <td><input type="number" class="form-control" name="quantities[]" min="1" value="{{ $material->pivot->quantity }}" readonly></td>
+                                                        <td> <button type="button" class="btn btn-secondary btn-sm delete-row" disabled><i class="fas fa-trash-alt"></i></button></td>
                                                     </tr>
                                                 @endforeach
                                             </tbody>
                                         </table>
+                                    </div>
+                                </div>
+                                <div class="col-md-12">
+                                    <div class="form-group">
+                                        <label for="detail">Detalles(*)</label>
+                                        <textarea class="form-control" id="detail" name="detail" placeholder="Ingrese detalles del préstamo" required>{{ $inventory->detail }}</textarea>
                                     </div>
                                 </div>
                             </div>
@@ -90,58 +80,6 @@
     </div>
 </div>
 
-<script>
-    document.querySelector('#materialTable_{{ $inventory->id }}').addEventListener('click', function(e) {
-            if (e.target.classList.contains('delete-row')) {
-                e.target.closest('tr').remove();
-            }
-    });
-
-    document.getElementById('addMaterialBtn_{{ $inventory->id }}').addEventListener('click', function() {
-        const materialId = document.getElementById('material_id_{{ $inventory->id }}').value;
-
-        if (materialId !== "") {
-            const materialName = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].text;
-            const materialDescription = document.getElementById('material_id_{{ $inventory->id }}').selectedOptions[0].getAttribute('data-description');
-            const tableBody = document.querySelector('#materialTable_{{ $inventory->id }} tbody');
-            let existingRow = null;
-
-            tableBody.querySelectorAll('tr').forEach(row => {
-                const existingMaterialId = row.querySelector('input[name="materials[]"]').value;
-                if (existingMaterialId === materialId) {
-                    existingRow = row;
-                }
-            });
-
-            if (existingRow) {
-                const quantityInput = existingRow.querySelector('input[name="quantities[]"]');
-                quantityInput.value = parseInt(quantityInput.value) + 1;
-            } else {
-                const newRow = document.createElement('tr');
-                newRow.innerHTML = `
-                    <td>${materialName}<input type="hidden" name="materials[]" value="${materialId}"></td>
-                    <td>${materialDescription}</td>
-                    <td><input type="number" class="form-control" name="quantities[]" min="1" value="1"></td>
-                    <td><button type="button" class="btn btn-danger btn-sm delete-row"><i class="fas fa-trash-alt"></i></button></td>
-                `;
-                tableBody.appendChild(newRow);
-
-                newRow.querySelector('.delete-row').addEventListener('click', function() {
-                    newRow.remove();
-                });
-            }
-
-            $('#material_id_{{ $inventory->id }}').val(null).trigger('change');
-        } else {
-            Swal.fire({
-                title: 'Error',
-                text: 'Por favor seleccione un material.',
-                icon: 'error',
-                confirmButtonText: 'Aceptar'
-            });
-        }
-    });
-</script>
 
 <style>
     #materialTable_{{ $inventory->id }} tbody tr:nth-child(odd) {

--- a/resources/views/inventories/index.blade.php
+++ b/resources/views/inventories/index.blade.php
@@ -96,15 +96,8 @@
 @section('js')
     <script>
         $(document).ready(function() {
-            $('.select2').select2();
-
             $('#createInventory').on('shown.bs.modal', function () {
-                $('.select2').select2({
-                    tags: true
-                });
-            });
-            $('#edit{{ $inventory->id }}').on('shown.bs.modal', function () {
-                $('.select2').select2({
+                $(this).find('.select2').select2({
                     tags: true
                 });
             });

--- a/resources/views/inventories/show.blade.php
+++ b/resources/views/inventories/show.blade.php
@@ -52,6 +52,14 @@
                                             @endforeach
                                         </tbody>
                                     </table>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="form-group">
+                                                <label>Detalles</label>
+                                                <textarea disabled class="form-control" rows="4">{{ $inventory->detail }}</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/materials/create.blade.php
+++ b/resources/views/materials/create.blade.php
@@ -70,7 +70,7 @@
                                         <div class="form-group">
                                             <label for="amount" class="form-label">Cantidad(*)</label>
                                             <input type="number" class="form-control" id="amount" name="amount"
-                                                placeholder="Ingresa la cantidad" required />
+                                                placeholder="Ingresa la cantidad" value="1" min="1" required oninput="this.value = Math.max(this.value, 1)" />
                                         </div>
                                     </div>
                                     <div class="col-lg-12">

--- a/resources/views/materials/edit.blade.php
+++ b/resources/views/materials/edit.blade.php
@@ -55,7 +55,7 @@
                                     <div class="col-lg-6">
                                         <div class="form-group">
                                             <label for="amount" class="form-label">Cantidad(*)</label>
-                                            <input type="number" class="form-control" name="amount" id="amount" value="{{ $material->amount }}" required>
+                                            <input type="number" class="form-control" name="amount" id="amount" value="{{ $material->amount }}" required readonly>
                                         </div>
                                     </div>
                                     <div class="col-lg-12">


### PR DESCRIPTION
Select2 Styles: Improved the styling of the Select2 component for better usability and visual consistency.

Inventory Quantity Handling: Updated the inventory management system to ensure that registered quantities are correctly added to the corresponding material quantities. Additionally, when an inventory record is deleted, the quantities of the associated materials are also adjusted accordingly.

Edit Inventory Modal Modifications:

Removed the "Add" button from the edit inventory modal.
Removed the material selection field.
The delete button for rows is now disabled, preventing the removal of materials during the edit process.
The quantity input field in the inventory editing modal has been set to read-only.

Detail Field Addition: Introduced a new detail field to the inventory model, updating the migration and the corresponding model. This change also required modifying the seeder to reflect the new field properly.

Seeder Updates: Adjusted the seeder logic so that when executed, the seeded materials accurately reflect the updated quantities in the inventory.

Material CRUD Adjustments:

The quantity input field in the material editing modal has been set to read-only.
The default value for the quantity input when adding a new material is now set to 1, and it does not allow input of 0 or negative numbers.