### PR TITLE
Fix double reload issue on inventory view

### DIFF
--- a/resources/views/inventories/index.blade.php
+++ b/resources/views/inventories/index.blade.php
@@ -117,8 +117,6 @@
                         text: successMessage,
                         icon: 'success',
                         confirmButtonText: 'Aceptar'
-                    }).then((result) => {
-                        window.location.href = "{{ route('inventories.index') }}";
                     });
                 }
                 if (errorMessage) {
@@ -127,8 +125,6 @@
                         text: errorMessage,
                         icon: 'error',
                         confirmButtonText: 'Aceptar'
-                    }).then((result) => {
-                        window.location.href = "{{ route('inventories.index') }}";
                     });
                 }
             });


### PR DESCRIPTION
This PR addresses an issue in the inventory view where the page would reload twice after displaying a success or error message. The cause was an additional redirection in the SweetAlert JavaScript block that executed upon confirming the message.

Changes made:

Removed the window.location.href redirection in the SweetAlert handling for success and error messages in inventories/index.blade.php.