### PR TITLE
Add support for including material returns in student loan reports

### DIFF
--- a/app/Http/Controllers/LoanController.php
+++ b/app/Http/Controllers/LoanController.php
@@ -309,6 +309,7 @@ class LoanController extends Controller
         $studentId = $request->studentId;
         $startDate = $request->startDate;
         $endDate = $request->endDate;
+        $includeReturns = $request->has('includeReturns') && $request->includeReturns === 'true';
         $authUser = auth()->user();
 
         $loans = Loan::with(['materials', 'createdBy'])
@@ -316,9 +317,13 @@ class LoanController extends Controller
             ->whereBetween('created_at', [$startDate, $endDate])
             ->get();
 
+        if ($includeReturns) {
+            $loans->load('materialReturns');
+        }
+
         $student = Student::findOrFail($studentId);
 
-        $pdf = Pdf::loadView('reports.loanStudentReport', compact('loans', 'student', 'startDate', 'endDate', 'authUser'))
+        $pdf = Pdf::loadView('reports.loanStudentReport', compact('loans', 'student', 'startDate', 'endDate', 'authUser', 'includeReturns'))
             ->setPaper('A4', 'portrait');
 
         return $pdf->stream('reporte_prestamos_' . $student->id . '.pdf');

--- a/resources/views/loans/reportStudents.blade.php
+++ b/resources/views/loans/reportStudents.blade.php
@@ -47,6 +47,7 @@
         const startDateInput = document.getElementById('startDate');
         const endDateInput = document.getElementById('endDate');
         const dateError = document.getElementById('dateError');
+        const includeReturnsCheckbox = document.getElementById('includeReturns');
 
         const validateDates = () => {
             const startDate = new Date(startDateInput.value);
@@ -61,8 +62,9 @@
             const studentId = document.getElementById('studentId').value;
             const startDate = startDateInput.value;
             const endDate = endDateInput.value;
+            const includeReturns = includeReturnsCheckbox.checked ? '&includeReturns=true' : '';
 
-            return `${form.action}?studentId=${encodeURIComponent(studentId)}&startDate=${encodeURIComponent(startDate)}&endDate=${encodeURIComponent(endDate)}`;
+            return `${form.action}?studentId=${encodeURIComponent(studentId)}&startDate=${encodeURIComponent(startDate)}&endDate=${encodeURIComponent(endDate)}${includeReturns}`;
         };
 
         form.addEventListener('submit', (event) => {


### PR DESCRIPTION
Pull Request Description
This PR enhances the student loan report generation feature by adding an optional parameter to include material return details. Key changes include:

Backend Updates:

Introduced the includeReturns parameter in the LoanController to handle the inclusion of material returns in the report.
Added the logic to load associated material return data when the parameter is set.
Frontend Enhancements:

Added a checkbox in the reportStudents.blade.php view to toggle the inclusion of material returns.
Updated JavaScript logic to append the includeReturns parameter to the report generation request.
Report Adjustments:

Updated the loanStudentReport.blade.php template to display returned quantities alongside loaned quantities when includeReturns is enabled.
Included a separate table for detailed return records, grouped by loan and material.